### PR TITLE
Gameserver 네트워크 송/수신 처리 마무리

### DIFF
--- a/RTWServer/Game/GamePacketHandler.cs
+++ b/RTWServer/Game/GamePacketHandler.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using RTWServer.Enum;
-using RTWServer.ServerCore.implementation;
 using RTWServer.ServerCore.Interface;
 
 namespace RTWServer.Game;
@@ -14,7 +13,7 @@ public class GamePacketHandler : IPacketHandler
         _logger = loggerFactory.CreateLogger<GamePacketHandler>();
     }
 
-    public async Task HandlePacketAsync(IPacket packet, ClientSession clientSession)
+    public async Task HandlePacketAsync(IPacket packet, IClientSession clientSession)
     {
         // _logger.LogInformation($"PacketId: {packet.PacketId}");
 

--- a/RTWServer/ServerCore/Interface/IClientSession.cs
+++ b/RTWServer/ServerCore/Interface/IClientSession.cs
@@ -7,6 +7,4 @@ public interface IClientSession
     Task StartSessionAsync(CancellationToken token);
     
     Task SendAsync(IPacket packet);
-    
-    void Disconnect();
 }

--- a/RTWServer/ServerCore/Interface/IClientSession.cs
+++ b/RTWServer/ServerCore/Interface/IClientSession.cs
@@ -1,0 +1,12 @@
+namespace RTWServer.ServerCore.Interface;
+
+public interface IClientSession
+{
+    string Id { get; }
+    
+    Task StartSessionAsync(CancellationToken token);
+    
+    Task SendAsync(IPacket packet);
+    
+    void Disconnect();
+}

--- a/RTWServer/ServerCore/Interface/IClientSessionManager.cs
+++ b/RTWServer/ServerCore/Interface/IClientSessionManager.cs
@@ -4,7 +4,7 @@ public interface IClientSessionManager
 {
     void AddClientSession(IClientSession clientSession);
     
-    void RemoveClientSession(IClientSession clientSession);
+    void RemoveClientSession(string id);
     
     IClientSession? GetClientSession(string id);
     

--- a/RTWServer/ServerCore/Interface/IClientSessionManager.cs
+++ b/RTWServer/ServerCore/Interface/IClientSessionManager.cs
@@ -1,0 +1,12 @@
+namespace RTWServer.ServerCore.Interface;
+
+public interface IClientSessionManager
+{
+    void AddClientSession(IClientSession clientSession);
+    
+    void RemoveClientSession(IClientSession clientSession);
+    
+    IClientSession? GetClientSession(string id);
+    
+    IEnumerable<IClientSession> GetAllClientSessions();
+}

--- a/RTWServer/ServerCore/Interface/IPacketHandler.cs
+++ b/RTWServer/ServerCore/Interface/IPacketHandler.cs
@@ -1,8 +1,6 @@
-using RTWServer.ServerCore.implementation;
-
 namespace RTWServer.ServerCore.Interface;
 
 public interface IPacketHandler
 {
-    Task HandlePacketAsync(IPacket packet, ClientSession clientSession);
+    Task HandlePacketAsync(IPacket packet, IClientSession clientSession);
 }

--- a/RTWServer/ServerCore/implementation/AsyncAwaitServer.cs
+++ b/RTWServer/ServerCore/implementation/AsyncAwaitServer.cs
@@ -61,21 +61,18 @@ class AsyncAwaitServer
 
     private async Task HandleClient(IClient client, CancellationToken token)
     {
-        IClientSession session = new ClientSession(client, _packetHandler, _packetSerializer, Guid.NewGuid().ToString());
-        
+        IClientSession session = new ClientSession(client, _packetHandler, _packetSerializer, _clientSessionManager,
+            Guid.NewGuid().ToString());
+
         try
         {
             _clientSessionManager.AddClientSession(session);
-            
+
             await session.StartSessionAsync(token);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "An error occurred while handling the client.");
-        }
-        finally
-        {
-            _clientSessionManager.RemoveClientSession(session);
         }
     }
 }

--- a/RTWServer/ServerCore/implementation/AsyncAwaitServer.cs
+++ b/RTWServer/ServerCore/implementation/AsyncAwaitServer.cs
@@ -15,14 +15,14 @@ class AsyncAwaitServer
     private readonly ILogger _logger;
 
     private readonly IPacketSerializer _packetSerializer;
-    private readonly ClientSessionManager _clientSessionManager;
+    private readonly IClientSessionManager _clientSessionManager;
 
     public AsyncAwaitServer(
         ServerListener serverListener,
         IPacketHandler packetHandler,
         ILoggerFactory loggerFactory,
         IPacketSerializer packetSerializer,
-        ClientSessionManager clientSessionManager
+        IClientSessionManager clientSessionManager
     )
     {
         _serverListener = serverListener;

--- a/RTWServer/ServerCore/implementation/AsyncAwaitServer.cs
+++ b/RTWServer/ServerCore/implementation/AsyncAwaitServer.cs
@@ -61,7 +61,7 @@ class AsyncAwaitServer
 
     private async Task HandleClient(IClient client, CancellationToken token)
     {
-        ClientSession session = new ClientSession(client, _packetHandler, _packetSerializer, Guid.NewGuid().ToString());
+        IClientSession session = new ClientSession(client, _packetHandler, _packetSerializer, Guid.NewGuid().ToString());
         
         try
         {

--- a/RTWServer/ServerCore/implementation/ClientSession.cs
+++ b/RTWServer/ServerCore/implementation/ClientSession.cs
@@ -5,7 +5,7 @@ using RTWServer.ServerCore.Interface;
 
 namespace RTWServer.ServerCore.implementation;
 
-public class ClientSession
+public class ClientSession : IClientSession
 {
     private const int BUFFER_SIZE = 4096;
 

--- a/RTWServer/ServerCore/implementation/ClientSessionManager.cs
+++ b/RTWServer/ServerCore/implementation/ClientSessionManager.cs
@@ -3,7 +3,7 @@ using RTWServer.ServerCore.Interface;
 
 namespace RTWServer.ServerCore.implementation;
 
-public class ClientSessionManager
+public class ClientSessionManager : IClientSessionManager
 {
     private ConcurrentDictionary<string, IClientSession> _clientSessions = new ();
     

--- a/RTWServer/ServerCore/implementation/ClientSessionManager.cs
+++ b/RTWServer/ServerCore/implementation/ClientSessionManager.cs
@@ -5,25 +5,23 @@ namespace RTWServer.ServerCore.implementation;
 
 public class ClientSessionManager : IClientSessionManager
 {
-    private ConcurrentDictionary<string, IClientSession> _clientSessions = new ();
-    
+    private ConcurrentDictionary<string, IClientSession> _clientSessions = new();
+
     public void AddClientSession(IClientSession clientSession)
     {
         _clientSessions[clientSession.Id] = clientSession;
     }
-    
-    public void RemoveClientSession(IClientSession clientSession)
+
+    public void RemoveClientSession(string id)
     {
-        _clientSessions.TryRemove(clientSession.Id, out _);
-        
-        clientSession.Disconnect();
+        _clientSessions.TryRemove(id, out _);
     }
-    
+
     public IClientSession? GetClientSession(string id)
     {
         return _clientSessions.GetValueOrDefault(id);
     }
-    
+
     public IEnumerable<IClientSession> GetAllClientSessions()
     {
         return _clientSessions.Values;

--- a/RTWServer/ServerCore/implementation/ClientSessionManager.cs
+++ b/RTWServer/ServerCore/implementation/ClientSessionManager.cs
@@ -1,29 +1,30 @@
 using System.Collections.Concurrent;
+using RTWServer.ServerCore.Interface;
 
 namespace RTWServer.ServerCore.implementation;
 
 public class ClientSessionManager
 {
-    private ConcurrentDictionary<string, ClientSession> _clientSessions = new ConcurrentDictionary<string, ClientSession>();
+    private ConcurrentDictionary<string, IClientSession> _clientSessions = new ();
     
-    public void AddClientSession(ClientSession clientSession)
+    public void AddClientSession(IClientSession clientSession)
     {
         _clientSessions[clientSession.Id] = clientSession;
     }
     
-    public void RemoveClientSession(ClientSession clientSession)
+    public void RemoveClientSession(IClientSession clientSession)
     {
         _clientSessions.TryRemove(clientSession.Id, out _);
         
         clientSession.Disconnect();
     }
     
-    public ClientSession? GetClientSession(string id)
+    public IClientSession? GetClientSession(string id)
     {
         return _clientSessions.GetValueOrDefault(id);
     }
     
-    public IEnumerable<ClientSession> GetAllClientSessions()
+    public IEnumerable<IClientSession> GetAllClientSessions()
     {
         return _clientSessions.Values;
     }


### PR DESCRIPTION
ClientSession의 경우 기존 Client에 송/수신 로직 처리를 위한 것
- Send/Receive 도중 연결이 끊긴 경우 처리
- 원하는 시점에 ClientSessionManager를 통해 세션을 참조