### PR TITLE
Add RTWServer unit tests

### DIFF
--- a/RTWTest/ServerCore/ClientSessionTests.cs
+++ b/RTWTest/ServerCore/ClientSessionTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using RTWServer.ServerCore.implementation;
+using RTWServer.ServerCore.Interface;
+using RTWServer.Packet;
+using NetworkDefinition.ErrorCode;
+
+namespace RTWTest.ServerCore;
+
+public class ClientSessionTests
+{
+    private class DummyClient : IClient
+    {
+        public Stream Stream { get; } = new MemoryStream();
+        public bool IsConnected => true;
+        public ValueTask<int> ReceiveAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken = default) => new ValueTask<int>(0);
+        public void Close() { }
+    }
+
+    [Test]
+    public async Task ValidateAuthTokenAsync_WithValidToken_SetsPropertiesAndReturnsSuccess()
+    {
+        var loggerFactory = LoggerFactory.Create(builder => { });
+        var client = new DummyClient();
+        var packetHandler = new Mock<IPacketHandler>().Object;
+        var packetSerializer = new Mock<IPacketSerializer>().Object;
+        var sessionManager = new Mock<IClientSessionManager>().Object;
+
+        var session = new ClientSession(client, packetHandler, packetSerializer, sessionManager, loggerFactory, "session1");
+
+        var (errorCode, playerId) = await session.ValidateAuthTokenAsync("token");
+
+        Assert.That(errorCode, Is.EqualTo(RTWErrorCode.Success));
+        Assert.That(playerId, Is.EqualTo("session1".GetHashCode()));
+        Assert.That(session.AuthToken, Is.EqualTo("token"));
+        Assert.That(session.IsAuthenticated, Is.True);
+    }
+
+    [Test]
+    public async Task ValidateAuthTokenAsync_WithEmptyToken_ReturnsAuthenticationFailed()
+    {
+        var loggerFactory = LoggerFactory.Create(builder => { });
+        var client = new DummyClient();
+        var packetHandler = new Mock<IPacketHandler>().Object;
+        var packetSerializer = new Mock<IPacketSerializer>().Object;
+        var sessionManager = new Mock<IClientSessionManager>().Object;
+
+        var session = new ClientSession(client, packetHandler, packetSerializer, sessionManager, loggerFactory, "session1");
+
+        var (errorCode, playerId) = await session.ValidateAuthTokenAsync(string.Empty);
+
+        Assert.That(errorCode, Is.EqualTo(RTWErrorCode.AuthenticationFailed));
+        Assert.That(playerId, Is.EqualTo(0));
+        Assert.That(session.IsAuthenticated, Is.False);
+    }
+}

--- a/RTWTest/ServerCore/PacketSerializerTests.cs
+++ b/RTWTest/ServerCore/PacketSerializerTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using RTWServer.Game;
+using RTWServer.Packet;
+using RTWServer.ServerCore.Interface;
+
+namespace RTWTest.ServerCore;
+
+public class PacketSerializerTests
+{
+    [Test]
+    public void SerializeAndDeserialize_EchoPacket_RoundTripsCorrectly()
+    {
+        IPacketFactory factory = new GamePacketFactory();
+        var serializer = new PacketSerializer(factory);
+        var original = new EchoPacket("hello"u8.ToArray());
+        Span<byte> buffer = stackalloc byte[serializer.GetHeaderSize() + original.GetPayloadSize()];
+
+        serializer.SerializeToBuffer(original, buffer);
+        var result = serializer.Deserialize(buffer);
+
+        Assert.That(result, Is.TypeOf<EchoPacket>());
+        Assert.That(((EchoPacket)result).GetPayloadSize(), Is.EqualTo(original.GetPayloadSize()));
+    }
+}


### PR DESCRIPTION
## Summary
- create ServerCore test folder
- add tests for ClientSession authentication
- add PacketSerializer round-trip test

## Testing
- `dotnet test` *(fails: Unable to load NuGet packages because the environment lacks network access)*