### PR TITLE
Load server endpoint from configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ rider.project.restore.info
 *.exe
 *.pdb
 *.json
+!RTWServer/appsettings.json
 *.deps.json
 *.runtimeconfig.json
 apphost.exe

--- a/RTWServer/Program.cs
+++ b/RTWServer/Program.cs
@@ -1,13 +1,18 @@
 ﻿using System.Net;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 using RTWServer.Game;
 using RTWServer.Packet;
 using RTWServer.ServerCore.implementation;
 using RTWServer.ServerCore.Interface;
 
-// TODO : 설정 파일에서 IP 주소와 포트 번호를 읽어와서 사용하도록 수정
-string ipAddress = "127.0.0.1";
-int port = 5000;
+IConfiguration configuration = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
+    .AddJsonFile("appsettings.json", optional: true)
+    .Build();
+
+string ipAddress = configuration.GetValue("ServerSettings:IPAddress", "127.0.0.1");
+int port = configuration.GetValue("ServerSettings:Port", 5000);
 
 // Create logger factory and logger
 ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>

--- a/RTWServer/RTWServer.csproj
+++ b/RTWServer/RTWServer.csproj
@@ -10,6 +10,8 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0-rc.2.24473.5" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0-rc.2.24473.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-rc.2.24473.5" />
     </ItemGroup>
 
     <ItemGroup>
@@ -17,8 +19,14 @@
       <Folder Include="Packet\Connection\" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <ProjectReference Include="..\NetworkDefinition\NetworkDefinition.csproj" />
-    </ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/RTWServer/appsettings.json
+++ b/RTWServer/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "ServerSettings": {
+    "IPAddress": "127.0.0.1",
+    "Port": 5000
+  }
+}


### PR DESCRIPTION
## Summary
- allow storing appsettings.json in repo
- read `ServerSettings` from `appsettings.json`
- copy config file on build
- include configuration packages

## Testing
- `dotnet test -c Release` *(fails: `dotnet` not found)*